### PR TITLE
Remove unnecessary specify on .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,3 @@ Session.vim
 
 # Catkin custom files
 CATKIN_IGNORE
->>>>>>> master


### PR DESCRIPTION
コンフリクト解決時のテキスト除去作業にミスがあったので修正