### PR TITLE
Refactor driver pkg edition 2

### DIFF
--- a/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
+++ b/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
@@ -1,4 +1,6 @@
 /**
+The original code:
+
 Copyright (c) 2015, Yusuke Doi
 All rights reserved.
 

--- a/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
+++ b/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
@@ -34,7 +34,6 @@ either expressed or implied, of the FreeBSD Project.
 /* Define pulse width time of the stepping motor. */
 #define PULSE_WIDTH_MICRO_SECOND 500
 
-/* Define direction of angular z. */
 enum {
   LEFT,
   RIGHT,
@@ -85,7 +84,6 @@ void steerCb(const geometry_msgs::Twist& msg) {
   if (msg.angular.z < 0 && time > 50) gen_pluse(LEFT, time); // Minus mean CCW or right.
   else if (msg.angular.z > 0 && time > 50) gen_pluse(RIGHT, time); // Plus mean CW or left.
   else gen_pluse(KEEP, 0); // Zero mean keep steer.
-  /* move task */
 }
 
 /**

--- a/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
+++ b/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
@@ -34,13 +34,15 @@ either expressed or implied, of the FreeBSD Project.
 /* Define pulse width time of the stepping motor. */
 #define PULSE_WIDTH_MICRO_SECOND 500
 
-enum {
+enum
+{
   LEFT,
   RIGHT,
   KEEP
 };
 
-enum {
+enum
+{
   cw_plus = 3,
   cw_minus,
   ccw_plus,
@@ -57,9 +59,11 @@ const unsigned int PULSE_FREQUENCY = 1000l * 1000 / (PULSE_WIDTH_MICRO_SECOND * 
 ros::NodeHandle nh; // The nodeHandle.
 ros::Subscriber<geometry_msgs::Twist> sub("steer_ctrl", &steerCb); // Set subscribe the motor_driver topic.
 
-void setup() {
+void setup()
+{
   /* Set pins Mode. */
-  for (int i = cw_plus; i < ccw_minus + 1; i++) { // 3: CW+, 4: CW-, 5: CCW+, 6:CCW-
+  for (int i = cw_plus; i < ccw_minus + 1; i++)
+  { // 3: CW+, 4: CW-, 5: CCW+, 6:CCW-
     pinMode(i, OUTPUT);
     digitalWrite(i, LOW); // Default pin status is LOW.
   }
@@ -68,7 +72,8 @@ void setup() {
   nh.subscribe(sub); // Start subscribe the "steer_ctrl" topic.
 }
 
-void loop() {
+void loop()
+{
   nh.spinOnce(); // Check topic and if change it, run the call back function.
 }
 
@@ -79,7 +84,8 @@ void loop() {
  * @author "Yusuke Doi"
  * @param msg This param is msg object of the motor_driver topic.
  */
-void steerCb(const geometry_msgs::Twist& msg) {
+void steerCb(const geometry_msgs::Twist& msg)
+{
   int time = msg.angular.x * 10;
   if (msg.angular.z < 0 && time > 50) gen_pluse(LEFT, time); // Minus mean CCW or right.
   else if (msg.angular.z > 0 && time > 50) gen_pluse(RIGHT, time); // Plus mean CW or left.
@@ -92,8 +98,10 @@ void steerCb(const geometry_msgs::Twist& msg) {
  * @author "Yusuke Doi"
  * @param direction Steer to direction.
  */
-void gen_pluse(const char direction, double time) {
-  switch (direction) {
+void gen_pluse(const char direction, double time)
+{
+  switch (direction)
+  {
   case LEFT: // Task steer left.
     noTone(cw_plus); // Unset tone. If don't running tone, not happen.
     tone(ccw_plus, PULSE_FREQUENCY, time); // Write pulse to CCW pin. turn to CW.

--- a/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
+++ b/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
@@ -29,27 +29,21 @@ either expressed or implied, of the FreeBSD Project.
 #include <ros.h> // Use ros_lib.
 #include <geometry_msgs/Twist.h> // Use Twist.msg. -> [linear(x,y,z), angular(x,y,z)]
 
-/* Define pin numbers. */
-#define ACCEL 9
-#define BACK_GEAR 8
-#define CW 3
-#define CCW 4
 /* Define pulse width time of the stepping motor. */
 #define PULSE_WIDTH_MICRO_SECOND 500
-/* Define max speed to 220. */
-#define MAX_SPEED 220
 /* Define direction of angular z. */
-#define LEFT 0
-#define RIGHT 1
-#define KEEP 2
-/* Define direction of back gear. */
-#define FORWARD 0
-#define BACK 1
+enum {
+  LEFT,
+  RIGHT,
+  KEEP
+};
 
-const int cw_plus = 3;
-const int cw_minus = 4;
-const int ccw_plus = 5;
-const int ccw_minus = 6;
+enum {
+  cw_plus = 3,
+  cw_minus,
+  ccw_plus,
+  ccw_minus
+};
 
 /* Declare proto type functions. */
 void gen_pulse(const char direction, double time); // Write pulse to the stepping motor.

--- a/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
+++ b/cirkit_unit03_driver/arduino/steer_ctrl/steer_ctrl.ino
@@ -33,6 +33,7 @@ either expressed or implied, of the FreeBSD Project.
 
 /* Define pulse width time of the stepping motor. */
 #define PULSE_WIDTH_MICRO_SECOND 500
+
 /* Define direction of angular z. */
 enum {
   LEFT,
@@ -60,8 +61,8 @@ ros::Subscriber<geometry_msgs::Twist> sub("steer_ctrl", &steerCb); // Set subscr
 void setup() {
   /* Set pins Mode. */
   for (int i = cw_plus; i < ccw_minus + 1; i++) { // 3: CW+, 4: CW-, 5: CCW+, 6:CCW-
-      pinMode(i, OUTPUT);
-      digitalWrite(i, LOW); // Default pin status is LOW.
+    pinMode(i, OUTPUT);
+    digitalWrite(i, LOW); // Default pin status is LOW.
   }
   /* Node handle setting. */
   nh.initNode(); // First setup the node handle.
@@ -84,7 +85,7 @@ void steerCb(const geometry_msgs::Twist& msg) {
   if (msg.angular.z < 0 && time > 50) gen_pluse(LEFT, time); // Minus mean CCW or right.
   else if (msg.angular.z > 0 && time > 50) gen_pluse(RIGHT, time); // Plus mean CW or left.
   else gen_pluse(KEEP, 0); // Zero mean keep steer.
-   /* move task */
+  /* move task */
 }
 
 /**
@@ -96,17 +97,16 @@ void steerCb(const geometry_msgs::Twist& msg) {
 void gen_pluse(const char direction, double time) {
   switch (direction) {
   case LEFT: // Task steer left.
-      noTone(cw_plus); // Unset tone. If don't running tone, not happen.
-      tone(ccw_plus, PULSE_FREQUENCY, time); // Write pulse to CCW pin. turn to CW.
-      break;
+    noTone(cw_plus); // Unset tone. If don't running tone, not happen.
+    tone(ccw_plus, PULSE_FREQUENCY, time); // Write pulse to CCW pin. turn to CW.
+    break;
   case RIGHT: // Task steer right.
-      noTone(ccw_plus); // Unset tone. If don't running tone, not happen.
-      tone(cw_plus, PULSE_FREQUENCY, time); // Write pulse to CW pin. turn to CCW.
-      break;
+    noTone(ccw_plus); // Unset tone. If don't running tone, not happen.
+    tone(cw_plus, PULSE_FREQUENCY, time); // Write pulse to CW pin. turn to CCW.
+    break;
   case KEEP: default: // set CW and CCW to low.
-      noTone(cw_plus); // Unset tone. If don't running tone, not happen.
-      noTone(ccw_plus); // Unset tone. If don't running tone, not happen.
-      break;
+    noTone(cw_plus); // Unset tone. If don't running tone, not happen.
+    noTone(ccw_plus); // Unset tone. If don't running tone, not happen.
+    break;
   }
 }
-

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -60,40 +60,28 @@ class ThirdRobotInterface {
 public:
   //! Constructor
   ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01);
-
   //! Destructor
   ~ThirdRobotInterface();
-
   //! Open the serial port
   virtual int openSerialPort();
-
   //! Setting the serial port
   virtual int setSerialPort();
-
   //! Close the serial port
   virtual int closeSerialPort();
-
   //! Setting params
   virtual void setParams(double pulse_rate, double geer_rate, double wheel_diameter_right, double wheel_diameter_left, double tred_width);
-
   //! Drive
   virtual geometry_msgs::Twist drive(double linear_speed, double angular_speed);
-
   //! Drive direct
   virtual geometry_msgs::Twist driveDirect(double front_angular, double rear_speed);// front_angular in [deg]
-
   //! Read the encoder pulses from iMCs01
   virtual int getEncoderPacket();
-
   //! Calculate Third robot odometry. Call after reading encoder pulses.
   virtual void calculateOdometry();
-
   //! Reset Third robot odometry.
   virtual void resetOdometry();
-
   //! Set new odometry.
   virtual void setOdometry(double new_x, double new_y, double new_yaw);
-
   //! write to iMCs01 (ccmd)
   virtual void writeCmd(ccmd cmd);
 
@@ -103,10 +91,8 @@ public:
   double odometry_y_;
   //! robot odometry yaw[rad]
   double odometry_yaw_;
-
   //! Front steer angle[deg].
   double steer_angle;
-
   //! Robot running status
   int stasis_;
 
@@ -121,63 +107,47 @@ protected:
   int parseEncoderPackets();
   int parseFrontEncoderCounts();
   int parseRearEncoderCounts();
-
   geometry_msgs::Twist fixFrontAngle(double angular_diff);
 
   //! For access to iMCs01
   struct uin cmd_uin;
   //struct uout cmd_uout;
   struct ccmd cmd_ccmd;
-
   //! Serial port to which the robot is connected
   std::string imcs01_port_name;
-
   //! File descriptor
   int fd_imcs01;
-
   //! Baudrate
   int baudrate_imcs01;
-
   //! Old and new termios struct
   termios oldtio_imcs01;
   termios newtio_imcs01;
-
   //! Delta rear encoder counts.
   //! 0 is right, 1 is left.
   int delta_rear_encoder_counts[2] = {0, 0};
-
   //! Last rear encoder counts reading. For odometry calculation.
   //! 0 is right, 1 is left.
   int last_rear_encoder_counts[2] = {0, 0};
-
   //! Last time reading encoder
   double last_rear_encoder_time;
-
   //! Delta time
   double delta_rear_encoder_time;
-
   //! Delta dist
   //! 0 is right, 1 is left.
   double delta_dist[2] = {0, 0};
   double last_delta_dist[2] = {0, 0};
-
   //! [k-1]のyaw
   double last_odometry_yaw = 0.0;
   //! num of pulse
   double PulseRate = 40.0;
-
   //! GEER_RATE
   double GeerRate = 33.0;
-
   //! Wheel Diameter[m]
   double WheelDiameter[2] = {0.2705, 0.275};
-
   //! Tred width[m]
   double TredWidth = 0.595;
-
   //! Linear velocity
   double linear_velocity;
-
   //! Forward or Back mode flag
   int runmode;
 };

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -11,6 +11,7 @@
 
 // For std
 #include <string>
+#include <mutex>
 
 // For old c
 #include <termios.h>
@@ -150,6 +151,8 @@ protected:
   double linear_velocity;
   //! Forward or Back mode flag
   int runmode;
+  //! Mutex for communication
+  std::mutex communication_mutex;
 };
 }
 #endif // THIRD_ROBOT_INTERFACE_H_

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -76,7 +76,7 @@ namespace cirkit {
 class ThirdRobotInterface {
 public:
   //! Constructor
-  ThirdRobotInterface(std::string new_serial_port_imcs01, int new_baudrate_imcs01);
+  ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01);
 
   //! Destructor
   ~ThirdRobotInterface();

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -10,7 +10,6 @@
 #include "imcs01_driver/driver/urobotc.h"
 
 // For std
-#include <numeric> // what for?
 #include <string>
 
 // For old c

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -152,7 +152,7 @@ protected:
   //! Forward or Back mode flag
   int runmode;
   //! Mutex for communication
-  std::mutex communication_mutex;
+  std::mutex communication_mutex_;
 };
 }
 #endif // THIRD_ROBOT_INTERFACE_H_

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -36,21 +36,6 @@ enum {
   STOP_MODE
 };
 
-//! Robot max encoder counts
-#define ROBOT_MAX_ENCODER_COUNTS 65535
-
-//! Length of between front wheel and rear wheel [m]
-#define WHEELBASE_LENGTH 0.94
-
-//! Width of tread [m]
-#define TREAD_WIDTH 0.53
-
-
-//! Max linear velocity [m/s]
-#define MAX_LIN_VEL 1.11 // 1.11[m/s] => 4.0[km/h]
-
-//! Send packet size for ctrl stepping motor to arduino
-#define SENDSIZE 7
 
 template<typename T, typename M>
 inline double MIN(const T& a, const M& b) {

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -16,12 +16,14 @@
 // For old c
 #include <termios.h>
 
-enum {
+enum
+{
   FRONT,
   REAR
 };
 
-enum {
+enum
+{
   ROBOT_STASIS_FORWARD,
   ROBOT_STASIS_FORWARD_STOP,
   ROBOT_STASIS_BACK,
@@ -29,7 +31,8 @@ enum {
   ROBOT_STASIS_OTHERWISE
 };
 
-enum {
+enum
+{
   FORWARD_MODE,
   FORWARD_STOP_MODE,
   BACK_MODE,
@@ -39,25 +42,30 @@ enum {
 
 
 template<typename N, typename M>
-inline double MIN(const N& a, const M& b) {
+inline double MIN(const N& a, const M& b)
+{
   return a < b ? a : b;
 }
 
 template<typename N, typename M>
-inline double MAX(const N& a, const M& b) {
+inline double MAX(const N& a, const M& b)
+{
   return a > b ? a : b;
 }
 
 template<typename T>
-inline double NORMALIZE(const T& z) {
+inline double NORMALIZE(const T& z)
+{
   return atan2(sin(z), cos(z));
 }
 
 int plus_or_minus(double value);
 
-namespace cirkit {
+namespace cirkit
+{
 
-class ThirdRobotInterface {
+class ThirdRobotInterface
+{
 public:
   //! Constructor
   ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01);
@@ -125,18 +133,18 @@ protected:
   termios newtio_imcs01;
   //! Delta rear encoder counts.
   //! 0 is right, 1 is left.
-  int delta_rear_encoder_counts[2] = {0, 0};
+  int delta_rear_encoder_counts[2] {0, 0};
   //! Last rear encoder counts reading. For odometry calculation.
   //! 0 is right, 1 is left.
-  int last_rear_encoder_counts[2] = {0, 0};
+  int last_rear_encoder_counts[2] {0, 0};
   //! Last time reading encoder
   double last_rear_encoder_time;
   //! Delta time
   double delta_rear_encoder_time;
   //! Delta dist
   //! 0 is right, 1 is left.
-  double delta_dist[2] = {0, 0};
-  double last_delta_dist[2] = {0, 0};
+  double delta_dist[2] {0, 0};
+  double last_delta_dist[2] {0, 0};
   //! [k-1]のyaw
   double last_odometry_yaw = 0.0;
   //! num of pulse
@@ -144,7 +152,7 @@ protected:
   //! GEER_RATE
   double GeerRate = 33.0;
   //! Wheel Diameter[m]
-  double WheelDiameter[2] = {0.2705, 0.275};
+  double WheelDiameter[2] {0.2705, 0.275};
   //! Tred width[m]
   double TredWidth = 0.595;
   //! Linear velocity

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -37,13 +37,13 @@ enum {
 };
 
 
-template<typename T, typename M>
-inline double MIN(const T& a, const M& b) {
+template<typename N, typename M>
+inline double MIN(const N& a, const M& b) {
   return a < b ? a : b;
 }
 
-template<typename T, typename M>
-inline double MAX(const T& a, const M& b) {
+template<typename N, typename M>
+inline double MAX(const N& a, const M& b) {
   return a > b ? a : b;
 }
 

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -14,7 +14,6 @@
 #include <string>
 
 // For old c
-#include <cstdint> // what for? and OLD
 #include <termios.h>
 
 enum {

--- a/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
+++ b/cirkit_unit03_driver/include/ThirdRobotInterface/ThirdRobotInterface.h
@@ -14,7 +14,7 @@
 #include <string>
 
 // For old c
-#include <stdint.h> // what for? and OLD
+#include <cstdint> // what for? and OLD
 #include <termios.h>
 
 enum {

--- a/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
+++ b/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
@@ -28,13 +28,13 @@ private:
   ros::Publisher odom_pub_;
   ros::Publisher steer_pub_;
   ros::Subscriber cmd_vel_sub_;
+  // cirkit unit03 interface object
+  cirkit::ThirdRobotInterface *cirkit_unit03_;
   // self member
   tf::TransformBroadcaster odom_broadcaster_;
   std::string imcs01_port_;
   ros::Time current_time_, last_time_;
   boost::mutex access_mutex_;
   geometry_msgs::Twist steer_dir_;
-  // cirkit unit03 interface object
-  cirkit::ThirdRobotInterface *cirkit_unit03_;
 };
 }

--- a/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
+++ b/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
@@ -14,7 +14,7 @@ class ThirdRobotInterface; // forward declaration
 
 class CirkitUnit03Driver {
 public:
-  CirkitUnit03Driver(const ros::NodeHandle& nh);
+  CirkitUnit03Driver(const std::string&, const ros::NodeHandle&);
   ~CirkitUnit03Driver();
   void resetCommunication();
   void run();

--- a/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
+++ b/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
@@ -3,6 +3,9 @@
  * Author : Arita Yuta(Kyutech)
  ******************************************************/
 
+// inclusive dependency
+#include "ThirdRobotInterface/ThirdRobotInterface.h"
+
 #include <ros/ros.h>
 #include <geometry_msgs/Twist.h>		// cmd_vel
 #include <tf/transform_broadcaster.h>
@@ -10,8 +13,6 @@
 #include <string>
 
 namespace cirkit {
-class ThirdRobotInterface; // forward declaration
-
 class CirkitUnit03Driver {
 public:
   CirkitUnit03Driver(const std::string&, const ros::NodeHandle&);
@@ -29,7 +30,7 @@ private:
   ros::Publisher steer_pub_;
   ros::Subscriber cmd_vel_sub_;
   // cirkit unit03 interface object
-  cirkit::ThirdRobotInterface *cirkit_unit03_;
+  cirkit::ThirdRobotInterface cirkit_unit03_;
   // self member
   tf::TransformBroadcaster odom_broadcaster_;
   std::string imcs01_port_;

--- a/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
+++ b/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
@@ -14,7 +14,7 @@ class ThirdRobotInterface; // forward declaration
 
 class CirkitUnit03Driver {
 public:
-  CirkitUnit03Driver(ros::NodeHandle nh);
+  CirkitUnit03Driver(const ros::NodeHandle& nh);
   ~CirkitUnit03Driver();
   void resetCommunication();
   void run();

--- a/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
+++ b/cirkit_unit03_driver/include/cirkit_unit03_driver.hpp
@@ -35,7 +35,6 @@ private:
   tf::TransformBroadcaster odom_broadcaster_;
   std::string imcs01_port_;
   ros::Time current_time_, last_time_;
-  boost::mutex access_mutex_;
   geometry_msgs::Twist steer_dir_;
 };
 }

--- a/cirkit_unit03_driver/launch/third_robot.launch
+++ b/cirkit_unit03_driver/launch/third_robot.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="third_robot_driver_node" pkg="third_robot_driver" type="third_robot_driver_node">
+  <node name="cirkit_unit03_driver_node" pkg="cirkit_unit03_driver" type="cirkit_unit03_driver_node">
     <param name="imcs01_port" type="string" value="/dev/urbtc0" />
     <param name="pulse_rate" type="double" value="45.0" />
     <param name="geer_rate" type="double" value="33.0" />

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -36,7 +36,7 @@ cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_p
   last_rear_encoder_time {0},
   stasis_ {ROBOT_STASIS_FORWARD_STOP}
 {
-  for(int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++) {
     delta_rear_encoder_counts[i] = -1;
     last_rear_encoder_counts[i] = 0;
   }
@@ -54,7 +54,7 @@ cirkit::ThirdRobotInterface::~ThirdRobotInterface() {
   write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd));
 
   //! iMCs01
-  if(fd_imcs01 > 0) {
+  if (fd_imcs01 > 0) {
     tcsetattr(fd_imcs01, TCSANOW, &oldtio_imcs01);
     close(fd_imcs01);
   }
@@ -143,7 +143,7 @@ int cirkit::ThirdRobotInterface::closeSerialPort() {
   drive(0.0, 0.0);
   usleep(1000);
 
-  if(fd_imcs01 > 0) {
+  if (fd_imcs01 > 0) {
     tcsetattr(fd_imcs01, TCSANOW, &oldtio_imcs01);
     close(fd_imcs01);
     fd_imcs01 = -1;
@@ -162,9 +162,9 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::drive(double linear_speed, dou
   double front_angle_deg = 0;
   double rear_speed_m_s = 0;
 
-  if(-0.005 < linear_speed && linear_speed < 0.005 && fabs(angular_speed) > 0.0) {
+  if (-0.005 < linear_speed && linear_speed < 0.005 && fabs(angular_speed) > 0.0) {
     rear_speed_m_s = 0.3;
-    if(angular_speed > 0) {
+    if (angular_speed > 0) {
       front_angle_deg = 60;
     } else {
       front_angle_deg = -60;
@@ -210,9 +210,9 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
   double duty = 0;
 
   // Forward
-  if(rear_speed >= 0.0) {
+  if (rear_speed >= 0.0) {
     double rear_speed_m_s = MIN(rear_speed, MAX_LIN_VEL); // return smaller
-    if(stasis_ == ROBOT_STASIS_FORWARD || stasis_ == ROBOT_STASIS_FORWARD_STOP) {
+    if (stasis_ == ROBOT_STASIS_FORWARD || stasis_ == ROBOT_STASIS_FORWARD_STOP) {
       // Now Forwarding
       // e = rear_speed_m_s - linear_velocity;
       // u = u1 + (gain_p + gain_i * delta_rear_encoder_time
@@ -223,7 +223,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       u = (int)(32767.0 + 32767.0 * average_spped_x *1.0);
       // ROS_INFO("a : %f", average_spped_x);
       // ROS_INFO("u : %f", u);
-      if(rear_speed == 0.0) {
+      if (rear_speed == 0.0) {
         u = 32767;
         average_spped_x = 0;
       }
@@ -254,7 +254,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       average_spped_x = 0;
       writeCmd(cmd_ccmd);
 
-      if(forward_stop_cnt >= 20) {
+      if (forward_stop_cnt >= 20) {
         stasis_ = ROBOT_STASIS_FORWARD_STOP;
         forward_stop_cnt = 0;
         for (int i = 0; i < 10; ++i) {
@@ -270,7 +270,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
   } else {
     // (rear_speed < 0) -> Back
     average_spped_x = 0;
-    if(stasis_ == ROBOT_STASIS_BACK_STOP || stasis_ == ROBOT_STASIS_BACK) {
+    if (stasis_ == ROBOT_STASIS_BACK_STOP || stasis_ == ROBOT_STASIS_BACK) {
       // Now backing
       cmd_ccmd.offset[0] = 32767; // iMCs01 CH101 PIN2 is 0[V]. Backing flag.
       cmd_ccmd.offset[1] = 60000; // Back is constant speed.
@@ -285,7 +285,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       ROS_INFO("ROBOT_STASIS_BACK");
     } else {
       // Now forwarding
-      if(back_stop_cnt >= 10) {
+      if (back_stop_cnt >= 10) {
         stasis_ = ROBOT_STASIS_BACK_STOP;
         back_stop_cnt = 0;
         cmd_ccmd.offset[0] = 32767; // iMCs01 CH101 PIN2 is 0[V].  Backing flag.

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 // for old c
+#include <cstdint> // what for? and OLD
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -21,7 +21,7 @@
 
 using namespace std; // FIXME: don't erode grobal scope
 
-cirkit::ThirdRobotInterface::ThirdRobotInterface(std::string new_serial_port_imcs01, int new_baudrate_imcs01) {
+cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01) {
   imcs01_port_name = new_serial_port_imcs01;
   fd_imcs01 = -1;
   baudrate_imcs01 = new_baudrate_imcs01;

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -23,12 +23,8 @@
 static constexpr int ROBOT_MAX_ENCODER_COUNTS {65535};
 //! Length of between front wheel and rear wheel [m]
 static constexpr double WHEELBASE_LENGTH {0.94};
-//! Width of tread [m]
-static constexpr double TREAD_WIDTH {0.53};
 //! Max linear velocity [m/s]
 static constexpr double MAX_LIN_VEL {1.11}; // 1.11[m/s] => 4.0[km/h]
-//! Send packet size for ctrl stepping motor to arduino
-static constexpr int SENDSIZE {7};
 
 using namespace std; // FIXME: don't erode grobal scope
 

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -19,6 +19,17 @@
 #include <sys/types.h> // for open()
 #include <unistd.h> // for close()
 
+//! Robot max encoder counts
+static constexpr int ROBOT_MAX_ENCODER_COUNTS {65535};
+//! Length of between front wheel and rear wheel [m]
+static constexpr double WHEELBASE_LENGTH {0.94};
+//! Width of tread [m]
+static constexpr double TREAD_WIDTH {0.53};
+//! Max linear velocity [m/s]
+static constexpr double MAX_LIN_VEL {1.11}; // 1.11[m/s] => 4.0[km/h]
+//! Send packet size for ctrl stepping motor to arduino
+static constexpr int SENDSIZE {7};
+
 using namespace std; // FIXME: don't erode grobal scope
 
 cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01) {

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -78,20 +78,16 @@ int cirkit::ThirdRobotInterface::openSerialPort() {
 // Set the serial port
 int cirkit::ThirdRobotInterface::setSerialPort() {
   // Setting iMCs01
-  if(fd_imcs01 > 0) {
+  if (fd_imcs01 > 0) {
     throw logic_error("imcs01 is already open");
   }
   fd_imcs01 = open(imcs01_port_name.c_str(), O_RDWR);
-  if(fd_imcs01 > 0)
-  {
+  if (fd_imcs01 > 0) {
     tcgetattr(fd_imcs01, &oldtio_imcs01);
-  }
-  else
-  {
+  } else {
     throw logic_error("Faild to open port: imcs01");
   }
-  if(ioctl(fd_imcs01, URBTC_CONTINUOUS_READ) < 0)
-  {
+  if (ioctl(fd_imcs01, URBTC_CONTINUOUS_READ) < 0) {
     throw logic_error("Faild to ioctl: URBTC_CONTINUOUS_READ");
   }
 
@@ -109,12 +105,10 @@ int cirkit::ThirdRobotInterface::setSerialPort() {
   cmd_ccmd.breaks     = SET_BREAKS | CH0 | CH1 | CH2 | CH3; //No Brake;
   cmd_ccmd.magicno    = 0x00;
 
-  if(ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0)
-  {
+  if (ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) {
     throw logic_error("Faild to ioctl: URBTC_COUNTER_SET");
   }
-  if(write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd)) < 0)
-  {
+  if (write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd)) < 0) {
     throw logic_error("Faild to write");
   }
 
@@ -277,8 +271,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
   } else {
     // (rear_speed < 0) -> Back
     average_spped_x = 0;
-    if(stasis_ == ROBOT_STASIS_BACK_STOP
-        || stasis_ == ROBOT_STASIS_BACK) {
+    if(stasis_ == ROBOT_STASIS_BACK_STOP || stasis_ == ROBOT_STASIS_BACK) {
       // Now backing
       cmd_ccmd.offset[0] = 32767; // iMCs01 CH101 PIN2 is 0[V]. Backing flag.
       cmd_ccmd.offset[1] = 60000; // Back is constant speed.

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -36,7 +36,8 @@ cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_p
   last_rear_encoder_time {0},
   stasis_ {ROBOT_STASIS_FORWARD_STOP}
 {
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++)
+  {
     delta_rear_encoder_counts[i] = -1;
     last_rear_encoder_counts[i] = 0;
   }
@@ -44,7 +45,8 @@ cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_p
   resetOdometry();
 }
 
-cirkit::ThirdRobotInterface::~ThirdRobotInterface() {
+cirkit::ThirdRobotInterface::~ThirdRobotInterface()
+{
   //  cout << "Destructor called\n" << endl;
   cmd_ccmd.offset[0] = 65535; // iMCs01 CH101 PIN2 is 5[V]. Forwarding flag.
   cmd_ccmd.offset[1] = 32767; // STOP
@@ -54,7 +56,8 @@ cirkit::ThirdRobotInterface::~ThirdRobotInterface() {
   write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd));
 
   //! iMCs01
-  if (fd_imcs01 > 0) {
+  if (fd_imcs01 > 0)
+  {
     tcsetattr(fd_imcs01, TCSANOW, &oldtio_imcs01);
     close(fd_imcs01);
   }
@@ -64,10 +67,14 @@ cirkit::ThirdRobotInterface::~ThirdRobotInterface() {
 
 // *****************************************************************************
 // Open the serial port
-int cirkit::ThirdRobotInterface::openSerialPort() {
-  try {
+int cirkit::ThirdRobotInterface::openSerialPort()
+{
+  try
+  {
     setSerialPort();
-  } catch(exception &e) {
+  }
+  catch(exception &e)
+  {
     cerr << e.what() << endl;
     return -1; // kill exception
   }
@@ -76,18 +83,24 @@ int cirkit::ThirdRobotInterface::openSerialPort() {
 
 // *****************************************************************************
 // Set the serial port
-int cirkit::ThirdRobotInterface::setSerialPort() {
+int cirkit::ThirdRobotInterface::setSerialPort()
+{
   // Setting iMCs01
-  if (fd_imcs01 > 0) {
+  if (fd_imcs01 > 0)
+  {
     throw logic_error("imcs01 is already open");
   }
   fd_imcs01 = open(imcs01_port_name.c_str(), O_RDWR);
-  if (fd_imcs01 > 0) {
+  if (fd_imcs01 > 0)
+  {
     tcgetattr(fd_imcs01, &oldtio_imcs01);
-  } else {
+  }
+  else
+  {
     throw logic_error("Faild to open port: imcs01");
   }
-  if (ioctl(fd_imcs01, URBTC_CONTINUOUS_READ) < 0) {
+  if (ioctl(fd_imcs01, URBTC_CONTINUOUS_READ) < 0)
+  {
     throw logic_error("Faild to ioctl: URBTC_CONTINUOUS_READ");
   }
 
@@ -105,10 +118,12 @@ int cirkit::ThirdRobotInterface::setSerialPort() {
   cmd_ccmd.breaks     = SET_BREAKS | CH0 | CH1 | CH2 | CH3; //No Brake;
   cmd_ccmd.magicno    = 0x00;
 
-  if (ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) {
+  if (ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0)
+  {
     throw logic_error("Faild to ioctl: URBTC_COUNTER_SET");
   }
-  if (write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd)) < 0) {
+  if (write(fd_imcs01, &cmd_ccmd, sizeof(cmd_ccmd)) < 0)
+  {
     throw logic_error("Faild to write");
   }
 
@@ -120,7 +135,8 @@ int cirkit::ThirdRobotInterface::setSerialPort() {
 
 // *****************************************************************************
 // Set params
-void cirkit::ThirdRobotInterface::setParams(double pulse_rate, double geer_rate, double wheel_diameter_right, double wheel_diameter_left, double tred_width) {
+void cirkit::ThirdRobotInterface::setParams(double pulse_rate, double geer_rate, double wheel_diameter_right, double wheel_diameter_left, double tred_width)
+{
   //! num of pulse
   PulseRate = pulse_rate;
   ROS_INFO("PulseRate : %lf", PulseRate);
@@ -139,11 +155,13 @@ void cirkit::ThirdRobotInterface::setParams(double pulse_rate, double geer_rate,
 }
 // *****************************************************************************
 // Close the serial port
-int cirkit::ThirdRobotInterface::closeSerialPort() {
+int cirkit::ThirdRobotInterface::closeSerialPort()
+{
   drive(0.0, 0.0);
   usleep(1000);
 
-  if (fd_imcs01 > 0) {
+  if (fd_imcs01 > 0)
+  {
     tcsetattr(fd_imcs01, TCSANOW, &oldtio_imcs01);
     close(fd_imcs01);
     fd_imcs01 = -1;
@@ -162,14 +180,20 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::drive(double linear_speed, dou
   double front_angle_deg = 0;
   double rear_speed_m_s = 0;
 
-  if (-0.005 < linear_speed && linear_speed < 0.005 && fabs(angular_speed) > 0.0) {
+  if (-0.005 < linear_speed && linear_speed < 0.005 && fabs(angular_speed) > 0.0)
+  {
     rear_speed_m_s = 0.3;
-    if (angular_speed > 0) {
+    if (angular_speed > 0)
+    {
       front_angle_deg = 60;
-    } else {
+    }
+    else
+    {
       front_angle_deg = -60;
     }
-  } else {
+  }
+  else
+  {
     rear_speed_m_s = linear_speed*1.0;
     front_angle_deg = angular_speed*1.2*(180.0/M_PI);
     //front_angle_deg = atan((angular_speed*1.1)/linear_speed) * (180.0/M_PI);
@@ -191,7 +215,8 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::drive(double linear_speed, dou
 //     ROBOT_STASIS_BACK_STOP    : Stoping but back mode
 //     ROBOT_STASIS_OTHERWISE    : Braking but not stop.
 
-geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angular, double rear_speed) {
+geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angular, double rear_speed)
+{
   static int forward_stop_cnt = 0;
   static int back_stop_cnt = 0;
   static int max_spped_x = 3.0;
@@ -210,9 +235,11 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
   double duty = 0;
 
   // Forward
-  if (rear_speed >= 0.0) {
+  if (rear_speed >= 0.0)
+  {
     double rear_speed_m_s = MIN(rear_speed, MAX_LIN_VEL); // return smaller
-    if (stasis_ == ROBOT_STASIS_FORWARD || stasis_ == ROBOT_STASIS_FORWARD_STOP) {
+    if (stasis_ == ROBOT_STASIS_FORWARD || stasis_ == ROBOT_STASIS_FORWARD_STOP)
+    {
       // Now Forwarding
       // e = rear_speed_m_s - linear_velocity;
       // u = u1 + (gain_p + gain_i * delta_rear_encoder_time
@@ -223,7 +250,8 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       u = (int)(32767.0 + 32767.0 * average_spped_x *1.0);
       // ROS_INFO("a : %f", average_spped_x);
       // ROS_INFO("u : %f", u);
-      if (rear_speed == 0.0) {
+      if (rear_speed == 0.0)
+      {
         u = 32767;
         average_spped_x = 0;
       }
@@ -239,7 +267,9 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       writeCmd(cmd_ccmd);
 
       stasis_ = ROBOT_STASIS_FORWARD;
-    } else {
+    }
+    else
+    {
       // Now Backing
       // Need to stop once.
       cmd_ccmd.offset[0] = 65535; // iMCs01 CH101 PIN2 is 5[V]. Forwarding flag. 32767
@@ -254,23 +284,30 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
       average_spped_x = 0;
       writeCmd(cmd_ccmd);
 
-      if (forward_stop_cnt >= 20) {
+      if (forward_stop_cnt >= 20)
+      {
         stasis_ = ROBOT_STASIS_FORWARD_STOP;
         forward_stop_cnt = 0;
-        for (int i = 0; i < 10; ++i) {
+        for (int i = 0; i < 10; ++i)
+        {
           cmd_ccmd.offset[0] = 65535; // iMCs01 CH101 PIN2 is 5[V]. Forwarding flag. 32767
           cmd_ccmd.offset[1] = 32767; // STOP
           writeCmd(cmd_ccmd);
         }
-      } else {
+      }
+      else
+      {
         stasis_ = ROBOT_STASIS_OTHERWISE;
         forward_stop_cnt++;
       }
     }
-  } else {
+  }
+  else
+  {
     // (rear_speed < 0) -> Back
     average_spped_x = 0;
-    if (stasis_ == ROBOT_STASIS_BACK_STOP || stasis_ == ROBOT_STASIS_BACK) {
+    if (stasis_ == ROBOT_STASIS_BACK_STOP || stasis_ == ROBOT_STASIS_BACK)
+    {
       // Now backing
       cmd_ccmd.offset[0] = 32767; // iMCs01 CH101 PIN2 is 0[V]. Backing flag.
       cmd_ccmd.offset[1] = 60000; // Back is constant speed.
@@ -283,9 +320,12 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
 
       stasis_ = ROBOT_STASIS_BACK;
       ROS_INFO("ROBOT_STASIS_BACK");
-    } else {
+    }
+    else
+    {
       // Now forwarding
-      if (back_stop_cnt >= 10) {
+      if (back_stop_cnt >= 10)
+      {
         stasis_ = ROBOT_STASIS_BACK_STOP;
         back_stop_cnt = 0;
         cmd_ccmd.offset[0] = 32767; // iMCs01 CH101 PIN2 is 0[V].  Backing flag.
@@ -293,7 +333,9 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
         writeCmd(cmd_ccmd);
         for (int i = 0; i < 300; ++i) usleep(1000);
         ROS_INFO("ROBOT_STASIS_BACK_STOP");
-      } else {
+      }
+      else
+      {
         cmd_ccmd.offset[0] = 65535; // iMCs01 CH101 PIN2 is 0[V].  Backing flag.
         cmd_ccmd.offset[1] = 32767; // STOP
         usleep(50000);
@@ -322,24 +364,30 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
 
 // *****************************************************************************
 // Read the encoders from iMCs01
-int cirkit::ThirdRobotInterface::getEncoderPacket() {
+int cirkit::ThirdRobotInterface::getEncoderPacket()
+{
   std::lock_guard<std::mutex> lck {communication_mutex_};
-  if (read(fd_imcs01, &cmd_uin, sizeof(cmd_uin)) != sizeof(cmd_uin)) {
+  if (read(fd_imcs01, &cmd_uin, sizeof(cmd_uin)) != sizeof(cmd_uin))
+  {
     return -1;
-  } else {
+  }
+  else
+  {
     return parseEncoderPackets();
   }
 }
 
 // *****************************************************************************
 // Parse encoder data
-int cirkit::ThirdRobotInterface::parseEncoderPackets() {
+int cirkit::ThirdRobotInterface::parseEncoderPackets()
+{
   parseFrontEncoderCounts();
   parseRearEncoderCounts();
   return 0;
 }
 
-int cirkit::ThirdRobotInterface::parseFrontEncoderCounts() {
+int cirkit::ThirdRobotInterface::parseFrontEncoderCounts()
+{
   const int ave_num = 5;
   static int cnt = 0;
   static vector<double> move_ave(ave_num);
@@ -351,9 +399,12 @@ int cirkit::ThirdRobotInterface::parseFrontEncoderCounts() {
   double R = 0.0;
   const double n = 1.00;
 
-  if (steer_encoder_counts == 0.0) {
+  if (steer_encoder_counts == 0.0)
+  {
     steer_angle = 0.0;
-  } else {
+  }
+  else
+  {
     double tmp = steer_encoder_counts*67.0/3633.0;
     tmp = tmp * M_PI /180;
     R = 0.96/tan(tmp);
@@ -366,7 +417,8 @@ int cirkit::ThirdRobotInterface::parseFrontEncoderCounts() {
   move_ave[cnt%5] = steer_angle;
   size_t size = move_ave.size();
   double sum = 0;
-  for (unsigned int i = 0; i < size; i++) {
+  for (unsigned int i = 0; i < size; i++)
+  {
     sum += move_ave[i];
   }
   steer_angle = sum / (double)size;
@@ -375,31 +427,39 @@ int cirkit::ThirdRobotInterface::parseFrontEncoderCounts() {
   return 0;
 }
 
-int cirkit::ThirdRobotInterface::parseRearEncoderCounts() {
+int cirkit::ThirdRobotInterface::parseRearEncoderCounts()
+{
   //! 0 is right, 1 is left.
-  int rear_encoder_counts[2] = {(int)(cmd_uin.ct[2]), -(int)(cmd_uin.ct[3])};
+  int rear_encoder_counts[2] {(int)(cmd_uin.ct[2]), -(int)(cmd_uin.ct[3])};
 
   delta_rear_encoder_time = (double)(cmd_uin.time) - last_rear_encoder_time;
-  if (delta_rear_encoder_time < 0) {
+  if (delta_rear_encoder_time < 0)
+  {
     delta_rear_encoder_time = 65535 - (last_rear_encoder_time - cmd_uin.time);
   }
   delta_rear_encoder_time = delta_rear_encoder_time / 1000.0; // [ms] -> [s]
   last_rear_encoder_time = (double)(cmd_uin.time);
 
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++)
+  {
     if (delta_rear_encoder_counts[i] == -1
-        || rear_encoder_counts[i] == last_rear_encoder_counts[i]) { // First time.
+        || rear_encoder_counts[i] == last_rear_encoder_counts[i])
+    { // First time.
 
       delta_rear_encoder_counts[i] = 0;
 
-    } else {
+    }
+    else
+    {
       delta_rear_encoder_counts[i] = rear_encoder_counts[i] - last_rear_encoder_counts[i];
 
       // checking imcs01 counter overflow.
-      if (delta_rear_encoder_counts[i] > ROBOT_MAX_ENCODER_COUNTS/10) {
+      if (delta_rear_encoder_counts[i] > ROBOT_MAX_ENCODER_COUNTS/10)
+      {
         delta_rear_encoder_counts[i] = delta_rear_encoder_counts[i] - ROBOT_MAX_ENCODER_COUNTS;
       }
-      if (delta_rear_encoder_counts[i] < -ROBOT_MAX_ENCODER_COUNTS/10) {
+      if (delta_rear_encoder_counts[i] < -ROBOT_MAX_ENCODER_COUNTS/10)
+      {
         delta_rear_encoder_counts[i] = delta_rear_encoder_counts[i] + ROBOT_MAX_ENCODER_COUNTS;
       }
     }
@@ -412,13 +472,15 @@ int cirkit::ThirdRobotInterface::parseRearEncoderCounts() {
 
 // *****************************************************************************
 // Reset Third Robot odometry
-void cirkit::ThirdRobotInterface::resetOdometry() {
+void cirkit::ThirdRobotInterface::resetOdometry()
+{
   setOdometry(0.0, 0.0, 0.0);
 }
 
 // *****************************************************************************
 // Set Third Robot odometry
-void cirkit::ThirdRobotInterface::setOdometry(double new_x, double new_y, double new_yaw) {
+void cirkit::ThirdRobotInterface::setOdometry(double new_x, double new_y, double new_yaw)
+{
   odometry_x_   = new_x;
   odometry_y_   = new_y;
   odometry_yaw_ = new_yaw;
@@ -427,9 +489,11 @@ void cirkit::ThirdRobotInterface::setOdometry(double new_x, double new_y, double
 
 // *****************************************************************************
 // Calculate Third Robot odometry
-void cirkit::ThirdRobotInterface::calculateOdometry() {
+void cirkit::ThirdRobotInterface::calculateOdometry()
+{
   // Pulse to distance
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++)
+  {
     delta_dist[i] = (delta_rear_encoder_counts[i]/PulseRate/GeerRate)*(WheelDiameter[i]*M_PI);
   }
 
@@ -447,46 +511,62 @@ void cirkit::ThirdRobotInterface::calculateOdometry() {
   odometry_y_ += (((last_delta_dist[0] + last_delta_dist[1]) * sin(last_odometry_yaw) +
       (delta_dist[0] + delta_dist[1]) * sin(odometry_yaw_)) / 4.0);
 
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++)
+  {
     last_delta_dist[i] = delta_dist[i];
   }
   last_odometry_yaw = odometry_yaw_;
 }
 
 
-void cirkit::ThirdRobotInterface::writeCmd(ccmd cmd) {
-  if (ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) { // FIXME: setup URBTC_COUNTER_SET on every communicate, realry? It wrong!
+void cirkit::ThirdRobotInterface::writeCmd(ccmd cmd)
+{
+  if (ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) // FIXME: setup URBTC_COUNTER_SET on every communicate, realry? It wrong!
+  {
     ROS_WARN("URBTC_COUNTER_SET fail."); // error // FIXME: error? if error, you should not write, right?
   }
   std::lock_guard<std::mutex> lck {communication_mutex_};
-  if (write(fd_imcs01, &cmd, sizeof(cmd)) < 0) {
+  if (write(fd_imcs01, &cmd, sizeof(cmd)) < 0)
+  {
     ROS_WARN("iMCs01 write fail.");
   }
 }
 
-geometry_msgs::Twist cirkit::ThirdRobotInterface::fixFrontAngle(double angular_diff) {
+geometry_msgs::Twist cirkit::ThirdRobotInterface::fixFrontAngle(double angular_diff)
+{
   geometry_msgs::Twist ret_steer;
-  if (angular_diff > 0) {
+  if (angular_diff > 0)
+  {
     ret_steer.angular.z = 1;
     ret_steer.angular.x = fabs(angular_diff);
     return ret_steer;
-  } else if(angular_diff < 0) {
+  }
+  else if(angular_diff < 0)
+  {
     ret_steer.angular.z = -1;
     ret_steer.angular.x = fabs(angular_diff);
     return ret_steer;
-  } else {
+  }
+  else
+  {
     ret_steer.angular.z = 0;
     ret_steer.angular.x = 0;
     return ret_steer;
   }
 }
 
-int plus_or_minus(double value) {
-  if (value > 0) {
+int plus_or_minus(double value)
+{
+  if (value > 0)
+  {
     return 1;
-  } else if(value < 0) {
+  }
+  else if(value < 0)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
     return 0;
   }
 }

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -212,8 +212,7 @@ geometry_msgs::Twist cirkit::ThirdRobotInterface::driveDirect(double front_angul
   // Forward
   if(rear_speed >= 0.0) {
     double rear_speed_m_s = MIN(rear_speed, MAX_LIN_VEL); // return smaller
-    if(stasis_ == ROBOT_STASIS_FORWARD
-        || stasis_ == ROBOT_STASIS_FORWARD_STOP) {
+    if(stasis_ == ROBOT_STASIS_FORWARD || stasis_ == ROBOT_STASIS_FORWARD_STOP) {
       // Now Forwarding
       // e = rear_speed_m_s - linear_velocity;
       // u = u1 + (gain_p + gain_i * delta_rear_encoder_time
@@ -455,7 +454,7 @@ void cirkit::ThirdRobotInterface::calculateOdometry() {
 
 
 void cirkit::ThirdRobotInterface::writeCmd(ccmd cmd) {
-  if(ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) {
+  if(ioctl(fd_imcs01, URBTC_COUNTER_SET) < 0) { // FIXME: setup URBTC_COUNTER_SET on every communicate, realry? It wrong!
     ROS_WARN("URBTC_COUNTER_SET fail."); // error // FIXME: error? if error, you should not write, right?
   }
   if(write(fd_imcs01, &cmd, sizeof(cmd)) < 0) {

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -8,12 +8,12 @@
 #include <vector>
 
 // for old c
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h> // for open()
 #include <math.h>
 #include <netinet/in.h>
-#include <stdio.h> // OLD
-#include <stdlib.h> // OLD
-#include <string.h> // FIXME: cstring
 #include <sys/ioctl.h> // for ioctl()
 #include <sys/stat.h> // for open()
 #include <sys/types.h> // for open()

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 // for old c
-#include <cstdint> // what for? and OLD
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
+++ b/cirkit_unit03_driver/src/ThirdRobotInterface/ThirdRobotInterface.cpp
@@ -28,18 +28,18 @@ static constexpr double MAX_LIN_VEL {1.11}; // 1.11[m/s] => 4.0[km/h]
 
 using namespace std; // FIXME: don't erode grobal scope
 
-cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01) {
-  imcs01_port_name = new_serial_port_imcs01;
-  fd_imcs01 = -1;
-  baudrate_imcs01 = new_baudrate_imcs01;
-
+cirkit::ThirdRobotInterface::ThirdRobotInterface(const std::string& new_serial_port_imcs01, int new_baudrate_imcs01)
+: imcs01_port_name {new_serial_port_imcs01},
+  df_imcs01 {-1},
+  baudrate_imcs01 {new_baudrate_imcs01}
+  steer_angle {0.0},
+  last_rear_encoder_time {0},
+  stasis_ {ROBOT_STASIS_FORWARD_STOP}
+{
   for(int i = 0; i < 2; i++) {
     delta_rear_encoder_counts[i] = -1;
     last_rear_encoder_counts[i] = 0;
   }
-  steer_angle = 0.0;
-  last_rear_encoder_time = 0;
-  stasis_ = ROBOT_STASIS_FORWARD_STOP;
 
   resetOdometry();
 }

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -16,7 +16,7 @@
 
 using namespace std; // FIXME: this software is library to cirkit_unit03_driver_node, don't erosion grobal area.
 
-cirkit::CirkitUnit03Driver::CirkitUnit03Driver(ros::NodeHandle nh)
+cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const ros::NodeHandle& nh)
 : nh_(nh),
   rate_(100),
   odom_pub_(nh_.advertise<nav_msgs::Odometry>("/odom", 1)),

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -16,19 +16,19 @@
 
 using namespace std; // FIXME: this software is library to cirkit_unit03_driver_node, don't erosion grobal area.
 
-cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, const ros::NodeHandle& nh)
+cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, const ros::NodeHandle& nh)
 : nh_ {nh},
   rate_ {100},
   odom_pub_ {nh_.advertise<nav_msgs::Odometry>("/odom", 1)},
   steer_pub_ {nh_.advertise<geometry_msgs::Twist>("/steer_ctrl", 1)},
   cmd_vel_sub_ {nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, boost::bind(&cirkit::CirkitUnit03Driver::cmdVelReceived, this, _1))},
+  cirkit_unit03_ {new cirkit::ThirdRobotInterface(imcs01_port, 0)},
   odom_broadcaster_ {},
-  imcs01_port_ {}, // over write by rosparam
+  imcs01_port_ {imcs01_port},
   current_time_ {},
   last_time_ {},
   access_mutex_ {},
-  steer_dir_ {},
-  cirkit_unit03_ {new cirkit::ThirdRobotInterface(imcs01_port_, 0)}
+  steer_dir_ {}
 {
   double pulse_rate {40.0};
   double geer_rate {33.0};

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -37,15 +37,20 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   resetCommunication();
 }
 
-cirkit::CirkitUnit03Driver::~CirkitUnit03Driver() {
+cirkit::CirkitUnit03Driver::~CirkitUnit03Driver()
+{
   cirkit_unit03_.closeSerialPort();
 }
 
-void cirkit::CirkitUnit03Driver::resetCommunication() {
-  if (cirkit_unit03_.openSerialPort() == 0) {
+void cirkit::CirkitUnit03Driver::resetCommunication()
+{
+  if (cirkit_unit03_.openSerialPort() == 0)
+  {
     ROS_INFO("Connected to cirkit unit03.");
     cirkit_unit03_.driveDirect(0, 0);
-  } else {
+  }
+  else
+  {
     ROS_FATAL("Could not connect to cirkit unit03.");
     throw std::runtime_error {"Could not connect to cirkit unit03"};
   }
@@ -54,12 +59,14 @@ void cirkit::CirkitUnit03Driver::resetCommunication() {
   cirkit_unit03_.setOdometry(0, 0, 0);
 }
 
-void cirkit::CirkitUnit03Driver::run() {
+void cirkit::CirkitUnit03Driver::run()
+{
   double last_x, last_y, last_yaw;
   double vel_x, vel_y, vel_yaw;
   double dt;
 
-  while (nh_.ok()) {
+  while (nh_.ok())
+  {
     current_time_ = ros::Time::now();
     last_x = cirkit_unit03_.odometry_x_;
     last_y = cirkit_unit03_.odometry_y_;
@@ -108,7 +115,8 @@ void cirkit::CirkitUnit03Driver::run() {
   }
 }
 
-void cirkit::CirkitUnit03Driver::cmdVelReceived(const geometry_msgs::Twist::ConstPtr& cmd_vel) {
+void cirkit::CirkitUnit03Driver::cmdVelReceived(const geometry_msgs::Twist::ConstPtr& cmd_vel)
+{
   steer_dir_ = cirkit_unit03_.drive(cmd_vel->linear.x, cmd_vel->angular.z);
   steer_pub_.publish(steer_dir_);
 }

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -10,9 +10,6 @@
 #include <iostream>
 #include <stdexcept>
 
-
-using namespace std; // FIXME: this software is library to cirkit_unit03_driver_node, don't erosion grobal area.
-
 cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, const ros::NodeHandle& nh)
 : nh_ {nh},
   rate_ {100},
@@ -50,12 +47,12 @@ cirkit::CirkitUnit03Driver::~CirkitUnit03Driver() {
 
 void cirkit::CirkitUnit03Driver::resetCommunication() {
   if (cirkit_unit03_.openSerialPort() == 0) {
-	  ROS_INFO("Connected to cirkit unit03.");
-	  cirkit_unit03_.driveDirect(0, 0);
-	} else {
-	  ROS_FATAL("Could not connect to cirkit unit03.");
-    throw runtime_error {"Could not connect to cirkit unit03"};
-	}
+    ROS_INFO("Connected to cirkit unit03.");
+    cirkit_unit03_.driveDirect(0, 0);
+  } else {
+    ROS_FATAL("Could not connect to cirkit unit03.");
+    throw std::runtime_error {"Could not connect to cirkit unit03"};
+  }
 
   cirkit_unit03_.resetOdometry();
   cirkit_unit03_.setOdometry(0, 0, 0);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -119,7 +119,6 @@ void cirkit::CirkitUnit03Driver::run() {
 }
 
 void cirkit::CirkitUnit03Driver::cmdVelReceived(const geometry_msgs::Twist::ConstPtr& cmd_vel) {
-  static int steer {0};
   {
     boost::mutex::scoped_lock {access_mutex_}; // why use mutex?
     steer_dir_ = cirkit_unit03_.drive(cmd_vel->linear.x, cmd_vel->angular.z);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -16,7 +16,7 @@
 
 using namespace std; // FIXME: this software is library to cirkit_unit03_driver_node, don't erosion grobal area.
 
-cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const ros::NodeHandle& nh)
+cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, const ros::NodeHandle& nh)
 : nh_(nh),
   rate_(100),
   odom_pub_(nh_.advertise<nav_msgs::Odometry>("/odom", 1)),
@@ -30,8 +30,6 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const ros::NodeHandle& nh)
   steer_dir_(),
   cirkit_unit03_(nullptr) // FIXME: init in constructor function
 {
-  ros::NodeHandle n("~");
-  n.param<std::string>("imcs01_port", imcs01_port_, "/dev/urbtc0");
   double pulse_rate = 40.0;
   double geer_rate = 33.0;
   double wheel_diameter_right = 0.275;

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -17,24 +17,24 @@
 using namespace std; // FIXME: this software is library to cirkit_unit03_driver_node, don't erosion grobal area.
 
 cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, const ros::NodeHandle& nh)
-: nh_(nh),
-  rate_(100),
-  odom_pub_(nh_.advertise<nav_msgs::Odometry>("/odom", 1)),
-  steer_pub_(nh_.advertise<geometry_msgs::Twist>("/steer_ctrl", 1)),
-  cmd_vel_sub_(nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, boost::bind(&cirkit::CirkitUnit03Driver::cmdVelReceived, this, _1))),
-  odom_broadcaster_(),
-  imcs01_port_(), // over write by rosparam
-  current_time_(),
-  last_time_(),
-  access_mutex_(),
-  steer_dir_(),
-  cirkit_unit03_(new cirkit::ThirdRobotInterface(imcs01_port_, 0))
+: nh_ {nh},
+  rate_ {100},
+  odom_pub_ {nh_.advertise<nav_msgs::Odometry>("/odom", 1)},
+  steer_pub_ {nh_.advertise<geometry_msgs::Twist>("/steer_ctrl", 1)},
+  cmd_vel_sub_ {nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, boost::bind(&cirkit::CirkitUnit03Driver::cmdVelReceived, this, _1))},
+  odom_broadcaster_ {},
+  imcs01_port_ {}, // over write by rosparam
+  current_time_ {},
+  last_time_ {},
+  access_mutex_ {},
+  steer_dir_ {},
+  cirkit_unit03_ {new cirkit::ThirdRobotInterface(imcs01_port_, 0)}
 {
-  double pulse_rate = 40.0;
-  double geer_rate = 33.0;
-  double wheel_diameter_right = 0.275;
-  double wheel_diameter_left = 0.275;
-  double tred_width = 0.595;
+  double pulse_rate {40.0};
+  double geer_rate {33.0};
+  double wheel_diameter_right {0.275};
+  double wheel_diameter_left {0.275};
+  double tred_width {0.595};
   n.param("pulse_rate", pulse_rate, pulse_rate);
   n.param("geer_rate", geer_rate, geer_rate);
   n.param("wheel_diameter_right", wheel_diameter_right, wheel_diameter_right);
@@ -52,13 +52,13 @@ cirkit::CirkitUnit03Driver::~CirkitUnit03Driver() {
 }
 
 void cirkit::CirkitUnit03Driver::resetCommunication() {
-  if(cirkit_unit03_->openSerialPort() == 0) {
+  if (cirkit_unit03_->openSerialPort() == 0) {
 	  ROS_INFO("Connected to cirkit unit03.");
 	  cirkit_unit03_->driveDirect(0, 0);
 	} else {
 	  ROS_FATAL("Could not connect to cirkit unit03.");
     delete cirkit_unit03_;
-    throw runtime_error("Could not connect to cirkit unit03");
+    throw runtime_error {"Could not connect to cirkit unit03"};
 	}
 
   cirkit_unit03_->resetOdometry();
@@ -70,14 +70,14 @@ void cirkit::CirkitUnit03Driver::run() {
   double vel_x, vel_y, vel_yaw;
   double dt;
 
-  while(nh_.ok()) {
+  while (nh_.ok()) {
     current_time_ = ros::Time::now();
     last_x = cirkit_unit03_->odometry_x_;
     last_y = cirkit_unit03_->odometry_y_;
     last_yaw = cirkit_unit03_->odometry_yaw_;
     {
-      boost::mutex::scoped_lock(access_mutex_); // why use mutex?
-      if( cirkit_unit03_->getEncoderPacket() == -1) ROS_ERROR("Could not retrieve encoder packet.");
+      boost::mutex::scoped_lock {access_mutex_}; // why use mutex?
+      if (cirkit_unit03_->getEncoderPacket() == -1) ROS_ERROR("Could not retrieve encoder packet.");
       else cirkit_unit03_->calculateOdometry();
     }
     dt = (current_time_ - last_time_).toSec();
@@ -85,7 +85,7 @@ void cirkit::CirkitUnit03Driver::run() {
     vel_y = (cirkit_unit03_->odometry_y_ - last_y)/dt;
     vel_yaw = (cirkit_unit03_->odometry_yaw_ - last_yaw)/dt;
 
-    geometry_msgs::Quaternion odom_quat = tf::createQuaternionMsgFromYaw(cirkit_unit03_->odometry_yaw_);
+    geometry_msgs::Quaternion odom_quat {tf::createQuaternionMsgFromYaw(cirkit_unit03_->odometry_yaw_)};
     geometry_msgs::TransformStamped odom_trans;
     odom_trans.header.stamp = current_time_;
     odom_trans.header.frame_id = "odom";
@@ -123,9 +123,9 @@ void cirkit::CirkitUnit03Driver::run() {
 }
 
 void cirkit::CirkitUnit03Driver::cmdVelReceived(const geometry_msgs::Twist::ConstPtr& cmd_vel) {
-  static int steer = 0;
+  static int steer {0};
   {
-    boost::mutex::scoped_lock(access_mutex_); // why use mutex?
+    boost::mutex::scoped_lock {access_mutex_}; // why use mutex?
     steer_dir_ = cirkit_unit03_->drive(cmd_vel->linear.x, cmd_vel->angular.z);
   }
   steer_pub_.publish(steer_dir_);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -29,7 +29,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   double wheel_diameter_right {0.275};
   double wheel_diameter_left {0.275};
   double tred_width {0.595};
-  ros::NodeHandle n {nh_, "~"};
+  ros::NodeHandle n {"~"};
   n.param("pulse_rate", pulse_rate, pulse_rate);
   n.param("geer_rate", geer_rate, geer_rate);
   n.param("wheel_diameter_right", wheel_diameter_right, wheel_diameter_right);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -3,9 +3,6 @@
 // dependency to ROS
 #include <nav_msgs/Odometry.h> // odom
 
-// dependency to Boost
-#include <boost/thread.hpp>
-
 // dependency to std
 #include <iostream>
 #include <stdexcept>

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -35,6 +35,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, 
   double wheel_diameter_right {0.275};
   double wheel_diameter_left {0.275};
   double tred_width {0.595};
+  ros::NodeHandle n {"~"};
   n.param("pulse_rate", pulse_rate, pulse_rate);
   n.param("geer_rate", geer_rate, geer_rate);
   n.param("wheel_diameter_right", wheel_diameter_right, wheel_diameter_right);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -28,7 +28,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, 
   last_time_(),
   access_mutex_(),
   steer_dir_(),
-  cirkit_unit03_(nullptr) // FIXME: init in constructor function
+  cirkit_unit03_(new cirkit::ThirdRobotInterface(imcs01_port_, 0))
 {
   double pulse_rate = 40.0;
   double geer_rate = 33.0;
@@ -41,7 +41,6 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port_, 
   n.param("wheel_diameter_left", wheel_diameter_left, wheel_diameter_left);
   n.param("tred_width", tred_width, tred_width);
 
-  cirkit_unit03_ = new cirkit::ThirdRobotInterface(imcs01_port_, 0); // FIXME: path received by argument for constructor
   cirkit_unit03_->setParams(pulse_rate, geer_rate, wheel_diameter_right, wheel_diameter_left, tred_width);
 
   resetCommunication();

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -15,7 +15,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   rate_ {100},
   odom_pub_ {nh_.advertise<nav_msgs::Odometry>("/odom", 1)},
   steer_pub_ {nh_.advertise<geometry_msgs::Twist>("/steer_ctrl", 1)},
-  cmd_vel_sub_ {nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, boost::bind(&cirkit::CirkitUnit03Driver::cmdVelReceived, this, _1))},
+  cmd_vel_sub_ {nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, &cirkit::CirkitUnit03Driver::cmdVelReceived, this)},
   cirkit_unit03_ {imcs01_port, 0},
   odom_broadcaster_ {},
   imcs01_port_ {imcs01_port},

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -35,7 +35,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   double wheel_diameter_right {0.275};
   double wheel_diameter_left {0.275};
   double tred_width {0.595};
-  ros::NodeHandle n {"~"};
+  ros::NodeHandle n {nh_, "~"};
   n.param("pulse_rate", pulse_rate, pulse_rate);
   n.param("geer_rate", geer_rate, geer_rate);
   n.param("wheel_diameter_right", wheel_diameter_right, wheel_diameter_right);

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver.cpp
@@ -1,8 +1,5 @@
 #include "cirkit_unit03_driver.hpp"
 
-// inclusive dependency
-#include "ThirdRobotInterface/ThirdRobotInterface.h"
-
 // dependency to ROS
 #include <nav_msgs/Odometry.h> // odom
 
@@ -22,7 +19,7 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   odom_pub_ {nh_.advertise<nav_msgs::Odometry>("/odom", 1)},
   steer_pub_ {nh_.advertise<geometry_msgs::Twist>("/steer_ctrl", 1)},
   cmd_vel_sub_ {nh_.subscribe<geometry_msgs::Twist>("/cmd_vel", 1, boost::bind(&cirkit::CirkitUnit03Driver::cmdVelReceived, this, _1))},
-  cirkit_unit03_ {new cirkit::ThirdRobotInterface(imcs01_port, 0)},
+  cirkit_unit03_ {imcs01_port, 0},
   odom_broadcaster_ {},
   imcs01_port_ {imcs01_port},
   current_time_ {},
@@ -42,28 +39,26 @@ cirkit::CirkitUnit03Driver::CirkitUnit03Driver(const std::string& imcs01_port, c
   n.param("wheel_diameter_left", wheel_diameter_left, wheel_diameter_left);
   n.param("tred_width", tred_width, tred_width);
 
-  cirkit_unit03_->setParams(pulse_rate, geer_rate, wheel_diameter_right, wheel_diameter_left, tred_width);
+  cirkit_unit03_.setParams(pulse_rate, geer_rate, wheel_diameter_right, wheel_diameter_left, tred_width);
 
   resetCommunication();
 }
 
 cirkit::CirkitUnit03Driver::~CirkitUnit03Driver() {
-  cirkit_unit03_->closeSerialPort();
-  delete cirkit_unit03_;
+  cirkit_unit03_.closeSerialPort();
 }
 
 void cirkit::CirkitUnit03Driver::resetCommunication() {
-  if (cirkit_unit03_->openSerialPort() == 0) {
+  if (cirkit_unit03_.openSerialPort() == 0) {
 	  ROS_INFO("Connected to cirkit unit03.");
-	  cirkit_unit03_->driveDirect(0, 0);
+	  cirkit_unit03_.driveDirect(0, 0);
 	} else {
 	  ROS_FATAL("Could not connect to cirkit unit03.");
-    delete cirkit_unit03_;
     throw runtime_error {"Could not connect to cirkit unit03"};
 	}
 
-  cirkit_unit03_->resetOdometry();
-  cirkit_unit03_->setOdometry(0, 0, 0);
+  cirkit_unit03_.resetOdometry();
+  cirkit_unit03_.setOdometry(0, 0, 0);
 }
 
 void cirkit::CirkitUnit03Driver::run() {
@@ -73,27 +68,27 @@ void cirkit::CirkitUnit03Driver::run() {
 
   while (nh_.ok()) {
     current_time_ = ros::Time::now();
-    last_x = cirkit_unit03_->odometry_x_;
-    last_y = cirkit_unit03_->odometry_y_;
-    last_yaw = cirkit_unit03_->odometry_yaw_;
+    last_x = cirkit_unit03_.odometry_x_;
+    last_y = cirkit_unit03_.odometry_y_;
+    last_yaw = cirkit_unit03_.odometry_yaw_;
     {
       boost::mutex::scoped_lock {access_mutex_}; // why use mutex?
-      if (cirkit_unit03_->getEncoderPacket() == -1) ROS_ERROR("Could not retrieve encoder packet.");
-      else cirkit_unit03_->calculateOdometry();
+      if (cirkit_unit03_.getEncoderPacket() == -1) ROS_ERROR("Could not retrieve encoder packet.");
+      else cirkit_unit03_.calculateOdometry();
     }
     dt = (current_time_ - last_time_).toSec();
-    vel_x = (cirkit_unit03_->odometry_x_ - last_x)/dt;
-    vel_y = (cirkit_unit03_->odometry_y_ - last_y)/dt;
-    vel_yaw = (cirkit_unit03_->odometry_yaw_ - last_yaw)/dt;
+    vel_x = (cirkit_unit03_.odometry_x_ - last_x)/dt;
+    vel_y = (cirkit_unit03_.odometry_y_ - last_y)/dt;
+    vel_yaw = (cirkit_unit03_.odometry_yaw_ - last_yaw)/dt;
 
-    geometry_msgs::Quaternion odom_quat {tf::createQuaternionMsgFromYaw(cirkit_unit03_->odometry_yaw_)};
+    geometry_msgs::Quaternion odom_quat {tf::createQuaternionMsgFromYaw(cirkit_unit03_.odometry_yaw_)};
     geometry_msgs::TransformStamped odom_trans;
     odom_trans.header.stamp = current_time_;
     odom_trans.header.frame_id = "odom";
     odom_trans.child_frame_id = "base_link";
 
-    odom_trans.transform.translation.x = cirkit_unit03_->odometry_x_;
-    odom_trans.transform.translation.y = cirkit_unit03_->odometry_y_;
+    odom_trans.transform.translation.x = cirkit_unit03_.odometry_x_;
+    odom_trans.transform.translation.y = cirkit_unit03_.odometry_y_;
     odom_trans.transform.translation.z = 0.0;
     odom_trans.transform.rotation = odom_quat;
 
@@ -104,8 +99,8 @@ void cirkit::CirkitUnit03Driver::run() {
     odom.header.frame_id = "odom";
 
     //set the position
-    odom.pose.pose.position.x = cirkit_unit03_->odometry_x_;
-    odom.pose.pose.position.y = cirkit_unit03_->odometry_y_;
+    odom.pose.pose.position.x = cirkit_unit03_.odometry_x_;
+    odom.pose.pose.position.y = cirkit_unit03_.odometry_y_;
     odom.pose.pose.position.z = 0.0;
     odom.pose.pose.orientation = odom_quat;
 
@@ -127,7 +122,7 @@ void cirkit::CirkitUnit03Driver::cmdVelReceived(const geometry_msgs::Twist::Cons
   static int steer {0};
   {
     boost::mutex::scoped_lock {access_mutex_}; // why use mutex?
-    steer_dir_ = cirkit_unit03_->drive(cmd_vel->linear.x, cmd_vel->angular.z);
+    steer_dir_ = cirkit_unit03_.drive(cmd_vel->linear.x, cmd_vel->angular.z);
   }
   steer_pub_.publish(steer_dir_);
 }

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
   std::string imcs01_port {"/dev/urbtc0"};
   n.param<std::string>("imcs01_port", imcs01_port, imcs01_port);
   
-  cirkit::CirkitUnit03Driver driver(std::move(imcs01_port), ros::NodeHandle {});
+  cirkit::CirkitUnit03Driver driver {std::move(imcs01_port), ros::NodeHandle {}};
   driver.run();
 
   return 0;

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
@@ -4,14 +4,18 @@
  ******************************************************/
 #include "cirkit_unit03_driver.hpp"
 
+#include <string>
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "cirkit_unit03_driver_node");
   ROS_INFO("cirkit unit03 robot driver for ROS.");
 
-  ros::NodeHandle nh;
+  ros::NodeHandle n {"~"};
+  std::string imcs01_port {"/dev/urbtc0"};
+  n.param<std::string>("imcs01_port", imcs01_port, imcs01_port);
   
-  cirkit::CirkitUnit03Driver driver(nh);
+  cirkit::CirkitUnit03Driver driver(std::move(imcs01_port), ros::NodeHandle {});
   driver.run();
 
   return 0;

--- a/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
+++ b/cirkit_unit03_driver/src/cirkit_unit03_driver_node.cpp
@@ -5,6 +5,7 @@
 #include "cirkit_unit03_driver.hpp"
 
 #include <string>
+#include <utility>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
このシリーズは気が済むまで続きます。

今回の変更はこちら

- ThirdRobotInterface の生ポインタをインスタンスに置き換え
- 全く使用していないdefineを削除
- 目についたdefineをconstexprに置き換え
- `**.h` includeファイルのうち `c**` に置き換えれそうなものを置き換え
- やっぱり全く使用していなかった`numeric.h`とか`stdint.h`を削除
- `using namespace std` を `cirkit_unit03_driver` の方だけ削除
    * ThirdRobotInterfaceの方はつかれたから後日
- タブ文字の残党狩り
- 記法統一の漏れ修正
- ユニバーサル初期化(統一初期化)導入

今回ほぼ完全にリファクタが完了したのは `cirkit_unit03_driver_node.cpp` だけです。

とりあえず進捗報告も兼ねてPull-requset送信します。