### PR TITLE
delete laserscan_merger.launch calling and rviz setting

### DIFF
--- a/cirkit_unit03_bringup/launch/cirkit_unit03_bringup.launch
+++ b/cirkit_unit03_bringup/launch/cirkit_unit03_bringup.launch
@@ -10,8 +10,4 @@
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" >
   </node>
 
-  <include file="$(find cirkit_unit03_control)/launch/laserscan_merger.launch" />
-
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find cirkit_unit03_viz)/config/autorun.rviz" required="true" />
-
 </launch>


### PR DESCRIPTION
laserscan_mergerとrvizは`apps`パッケージのlaunchから呼び出すようにしたので削除。
https://github.com/CIR-KIT-Unit03/cirkit_unit03_whole_issue/issues/19